### PR TITLE
スマホで閲覧時の表示修正

### DIFF
--- a/components/RankingTable.vue
+++ b/components/RankingTable.vue
@@ -164,11 +164,17 @@ function getMovementClass(movement: string | undefined): string {
   min-width: 600px;
 }
 
+@media (max-width: 768px) {
+  .ranking-table {
+    min-width: 100%;
+  }
+}
+
 .ranking-table th {
   background: #34495e;
   color: white;
   padding: 15px 10px;
-  text-align: left;
+  text-align: center;
   font-weight: 600;
   font-size: 0.9rem;
 }
@@ -313,7 +319,7 @@ function getMovementClass(movement: string | undefined): string {
   
   .ranking-table th,
   .ranking-table td {
-    padding: 8px 5px;
+    padding: 8px 4px;
     font-size: 0.8rem;
   }
   
@@ -325,13 +331,23 @@ function getMovementClass(movement: string | undefined): string {
     display: inline;
   }
   
-  .rank,
+  .rank {
+    width: 50px;
+  }
+  
   .movement {
-    width: 60px;
+    width: 70px;
+  }
+  
+  .address {
+    width: 35%;
+    min-width: 120px;
   }
   
   .amount {
-    min-width: 80px;
+    width: 25%;
+    min-width: 100px;
+    font-size: 0.75rem;
   }
   
   .expand-button {
@@ -343,12 +359,31 @@ function getMovementClass(movement: string | undefined): string {
 @media (max-width: 480px) {
   .ranking-table th,
   .ranking-table td {
-    padding: 6px 3px;
-    font-size: 0.75rem;
+    padding: 6px 2px;
+    font-size: 0.7rem;
   }
   
   .table-header h2 {
     font-size: 1.3rem;
+  }
+  
+  .rank {
+    width: 40px;
+  }
+  
+  .movement {
+    width: 60px;
+  }
+  
+  .address {
+    width: 40%;
+    min-width: 100px;
+  }
+  
+  .amount {
+    width: 30%;
+    min-width: 80px;
+    font-size: 0.7rem;
   }
   
   .expand-button {


### PR DESCRIPTION
### 実装した改善点
#### ✅ ヘッダーの改善
- 中央寄せ: すべてのテーブルヘッダーをtext-align: centerに変更
- 統一感: より整理された見た目
#### ✅ スマホ表示の最適化
- 768px以下（タブレット・大きめスマホ）
- 保有量列: width: 25%, min-width: 100pxで確実に表示
- アドレス列: width: 35%で適切な幅を確保
- パディング: padding: 8px 4pxで余白を調整
- 480px以下（小さめスマホ）
- 保有量列: width: 30%, min-width: 80px
- フォントサイズ: 0.7remでより小さく
- パディング: padding: 6px 2pxでよりコンパクト
#### ✅ 全体的な改善
- テーブル幅: モバイルでmin-width: 100%に調整
- レスポンシブ: 各画面サイズで保有量が確実に見える
- 可読性: 適切なフォントサイズとパディング